### PR TITLE
RdapEntity::getHandle() apparently can return int

### DIFF
--- a/src/Data/RdapEntity.php
+++ b/src/Data/RdapEntity.php
@@ -12,7 +12,7 @@ final class RdapEntity extends RdapObject {
      */
     protected $lang;
     /*
-     * @var string
+     * @var mixed
      */
     protected $handle;
     /**
@@ -104,9 +104,9 @@ final class RdapEntity extends RdapObject {
     }
 
     /**
-     * @return string|null
+     * @return mixed
      */
-    public function getHandle(): ?string {
+    public function getHandle() {
         return $this->handle;
     }
 

--- a/testrdap.php
+++ b/testrdap.php
@@ -10,7 +10,7 @@ include './vendor/autoload.php';
 //$search = '81.4.97.200';
 //$search = '82.135.96.210';
 //$search = '8.8.4.4';
-$search = 'loichinger.bayern';
+$search = 'bleibtreu.berlin';
 //$protocol = Metaregistrar\RDAP\Rdap::IPV4;
 $protocol = Metaregistrar\RDAP\Rdap::DOMAIN;
 


### PR DESCRIPTION
discovered when searching for a .berlin domain. To be safe I've removed
typehinting.
