### PR TITLE
fix: Array and string offset access syntax with curly braces is no longer supported

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "minimum-stability": "stable",
   "license": "proprietary",
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.4",
     "ext-json": "*"
   },
   "authors": [

--- a/src/Rdap.php
+++ b/src/Rdap.php
@@ -128,7 +128,7 @@ class Rdap {
                     // exact match
                     if ($number === $parameter) {
                         // check for slash as last character in the server name, if not, add it
-                        if ($service[1][0]{strlen($service[1][0]) - 1} !== '/') {
+                        if ($service[1][0][strlen($service[1][0]) - 1] !== '/') {
                             $service[1][0] .= '/';
                         }
 


### PR DESCRIPTION
Hello,
Fixed a compile error on PHP 8 cause depreacated on PHP 7.4
Compile Error: Array and string offset access syntax with curly braces is no longer supported